### PR TITLE
Adds testing macros for laravel collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ to write them yourself in every new application.
   - [Downloading](#downloading)
 - [Usage](#usage)
   - [`InteractsWithViews`](#interactswithviews)
+  - [`TestCollectionMacros`](#testcollectionmacros)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -42,7 +43,7 @@ and run `composer update` on the command line to download the package:
 ```
 
 ## Usage
-You will now have access to several traits to use in your test classes.
+You will now have access to several traits and macros to use in your test classes.
 
 ### `InteractsWithViews`
 This trait adds two view assertions: `assertViewExists` and `assertViewNotExists`.
@@ -72,6 +73,35 @@ class ServiceTest extends TestCase
         // ...
         
         $this->assertViewNotExists('some.view-file');
+    }
+}
+```
+
+### `TestCollectionMacros`
+This set of macros adds some assertions to laravel collections: `assertContains` and `assertNotContains`.
+They are used as follows:
+
+```php
+<?php
+
+use Sven\LaravelTestingUtils\Collections\TestCollectionMacros;
+use Illuminate\Foundation\Testing\TestCase;
+
+class ServiceTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        TestCollectionMacros::enable();
+    }
+        
+    /** @test */
+    public function it_fetches_some_data()
+    {
+        // ...
+        
+        $collection->assertContains('some-item');
+        $collection->assertNotContains('some-other-item');
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ class ServiceTest extends TestCase
 ```
 
 ### `TestCollectionMacros`
-This set of macros adds some assertions to laravel collections: `assertContains` and `assertNotContains`.
+This set of macros adds some assertions to Laravel collections: `assertContains` and `assertNotContains`.
 They are used as follows:
 
 ```php

--- a/src/Collections/TestCollectionMacros.php
+++ b/src/Collections/TestCollectionMacros.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sven\LaravelTestingUtils\Collections;
+
+use Illuminate\Support\Collection;
+
+class TestCollectionMacros
+{
+    public static function enable(): void
+    {
+        Collection::mixin(new TestCollectionMixin());
+    }
+}

--- a/src/Collections/TestCollectionMixin.php
+++ b/src/Collections/TestCollectionMixin.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Sven\LaravelTestingUtils\Collections;
+
+use PHPUnit\Framework\Assert as PHPUnit;
+
+/**
+ * @method bool contains($key, $operator = null, $value = null)
+ */
+class TestCollectionMixin
+{
+    /**
+     * Assert that an item exists in the collection.
+     *
+     * @return \Closure
+     */
+    public function assertContains()
+    {
+        return function ($item) {
+            /** @var \Illuminate\Support\Collection $this*/
+            PHPUnit::assertTrue(
+                $this->contains($item),
+                "Failed asserting that the collection contains the specified value."
+            );
+        };
+    }
+
+    /**
+     * Assert that an item does not exist in the collection.
+     *
+     * @return \Closure
+     */
+    public function assertNotContains()
+    {
+        return function ($item) {
+            /** @var \Illuminate\Support\Collection $this*/
+            PHPUnit::assertFalse(
+                $this->contains($item),
+                "Failed asserting that the collection does not contain the specified value."
+            );
+        };
+    }
+}

--- a/src/Collections/TestCollectionMixin.php
+++ b/src/Collections/TestCollectionMixin.php
@@ -16,10 +16,10 @@ class TestCollectionMixin
      */
     public function assertContains()
     {
-        return function ($item) {
+        return function ($key, $operator = null, $value = null) {
             /** @var \Illuminate\Support\Collection $this*/
             PHPUnit::assertTrue(
-                $this->contains($item),
+                $this->contains(...func_get_args()),
                 "Failed asserting that the collection contains the specified value."
             );
         };
@@ -32,10 +32,10 @@ class TestCollectionMixin
      */
     public function assertNotContains()
     {
-        return function ($item) {
+        return function ($key, $operator = null, $value = null) {
             /** @var \Illuminate\Support\Collection $this*/
             PHPUnit::assertFalse(
-                $this->contains($item),
+                $this->contains(...func_get_args()),
                 "Failed asserting that the collection does not contain the specified value."
             );
         };

--- a/src/Collections/TestCollectionMixin.php
+++ b/src/Collections/TestCollectionMixin.php
@@ -17,10 +17,10 @@ class TestCollectionMixin
     public function assertContains()
     {
         return function ($key, $operator = null, $value = null) {
-            /** @var \Illuminate\Support\Collection $this*/
+            /** @var \Illuminate\Support\Collection $this */
             PHPUnit::assertTrue(
                 $this->contains(...func_get_args()),
-                "Failed asserting that the collection contains the specified value."
+                'Failed asserting that the collection contains the specified value.'
             );
         };
     }
@@ -33,10 +33,10 @@ class TestCollectionMixin
     public function assertNotContains()
     {
         return function ($key, $operator = null, $value = null) {
-            /** @var \Illuminate\Support\Collection $this*/
+            /* @var \Illuminate\Support\Collection $this */
             PHPUnit::assertFalse(
                 $this->contains(...func_get_args()),
-                "Failed asserting that the collection does not contain the specified value."
+                'Failed asserting that the collection does not contain the specified value.'
             );
         };
     }

--- a/src/Collections/TestCollectionMixin.php
+++ b/src/Collections/TestCollectionMixin.php
@@ -17,7 +17,7 @@ class TestCollectionMixin
     public function assertContains()
     {
         return function ($key, $operator = null, $value = null) {
-            /** @var \Illuminate\Support\Collection $this */
+            /* @var \Illuminate\Support\Collection $this */
             PHPUnit::assertTrue(
                 $this->contains(...func_get_args()),
                 'Failed asserting that the collection contains the specified value.'

--- a/tests/Collections/CollectionContainsTest.php
+++ b/tests/Collections/CollectionContainsTest.php
@@ -21,9 +21,42 @@ class CollectionContainsTest extends TestCase
     }
 
     /** @test */
+    public function collection_contains_the_item_with_callable()
+    {
+        collect(['cap', 'thor'])->assertContains(function ($value) {
+            return $value == 'thor';
+        });
+    }
+
+    /** @test */
+    public function collection_contains_the_item_with_key_value_pair()
+    {
+        collect([['name' => 'cap'], ['name' => 'thor']])->assertContains('name', 'cap');
+    }
+
+    /** @test */
     public function collection_does_not_contain_the_item()
     {
         $this->expectException(AssertionFailedError::class);
+
         collect(['cap', 'thor'])->assertContains('hulk');
+    }
+
+    /** @test */
+    public function collection_does_not_contain_the_item_with_callable()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        collect(['cap', 'thor'])->assertContains(function ($value) {
+            return $value == 'hulk';
+        });
+    }
+
+    /** @test */
+    public function collection_does_not_contain_the_item_with_key_value_pair()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        collect([['name' => 'cap'], ['name' => 'thor']])->assertContains('name', 'hulk');
     }
 }

--- a/tests/Collections/CollectionContainsTest.php
+++ b/tests/Collections/CollectionContainsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sven\LaravelTestingUtils\Tests\Collections;
+
+use PHPUnit\Framework\AssertionFailedError;
+use Sven\LaravelTestingUtils\Collections\TestCollectionMacros;
+use Sven\LaravelTestingUtils\Tests\TestCase;
+
+class CollectionContainsTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        TestCollectionMacros::enable();
+    }
+
+    /** @test */
+    public function collection_contains_the_item()
+    {
+        collect(['cap', 'thor'])->assertContains('cap');
+    }
+
+    /** @test */
+    public function collection_does_not_contain_the_item()
+    {
+        $this->expectException(AssertionFailedError::class);
+        collect(['cap', 'thor'])->assertContains('hulk');
+    }
+}

--- a/tests/Collections/CollectionNotContainsTest.php
+++ b/tests/Collections/CollectionNotContainsTest.php
@@ -15,15 +15,48 @@ class CollectionNotContainsTest extends TestCase
     }
 
     /** @test */
+    public function collection_does_not_contain_the_item()
+    {
+        collect(['cap', 'thor'])->assertNotContains('hulk');
+    }
+
+    /** @test */
+    public function collection_does_not_contain_the_item_with_callable()
+    {
+        collect(['cap', 'thor'])->assertNotContains(function ($value) {
+            return $value == 'hulk';
+        });
+    }
+
+    /** @test */
+    public function collection_does_not_contain_the_item_with_key_value_pair()
+    {
+        collect([['name' => 'cap'], ['name' => 'thor']])->assertNotContains('name', 'hulk');
+    }
+
+    /** @test */
     public function collection_contains_the_item()
     {
         $this->expectException(AssertionFailedError::class);
+
         collect(['cap', 'thor'])->assertNotContains('cap');
     }
 
     /** @test */
-    public function collection_does_not_contain_the_item()
+    public function collection_contains_the_item_with_callable()
     {
-        collect(['cap', 'thor'])->assertNotContains('hulk');
+        $this->expectException(AssertionFailedError::class);
+
+        collect(['cap', 'thor'])->assertNotContains(function ($value) {
+            return $value == 'thor';
+        });
+    }
+
+    /** @test */
+    public function collection_contains_the_item_with_key_value_pair()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        collect([['name' => 'cap'], ['name' => 'thor']])->assertNotContains('name', 'cap');
     }
 }

--- a/tests/Collections/CollectionNotContainsTest.php
+++ b/tests/Collections/CollectionNotContainsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sven\LaravelTestingUtils\Tests\Collections;
+
+use PHPUnit\Framework\AssertionFailedError;
+use Sven\LaravelTestingUtils\Collections\TestCollectionMacros;
+use Sven\LaravelTestingUtils\Tests\TestCase;
+
+class CollectionNotContainsTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        TestCollectionMacros::enable();
+    }
+
+    /** @test */
+    public function collection_contains_the_item()
+    {
+        $this->expectException(AssertionFailedError::class);
+        collect(['cap', 'thor'])->assertNotContains('cap');
+    }
+
+    /** @test */
+    public function collection_does_not_contain_the_item()
+    {
+        collect(['cap', 'thor'])->assertNotContains('hulk');
+    }
+}


### PR DESCRIPTION
related to https://github.com/svenluijten/laravel-testing-utils/issues/3 
so far... 
- Few problems with phpstan, macros are too much magic for the tool. (any advice?)
- Took the `TestCollectionMacros::enable();` approach inspired by [carbon business-day](https://github.com/kylekatarnls/business-day). Also, there is no need for the container.
- Added some very basic tests.
