### PR TITLE
Added assertViewHasDeep assertion to TestResponse

### DIFF
--- a/src/Responses/TestResponseMacros.php
+++ b/src/Responses/TestResponseMacros.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sven\LaravelTestingUtils\Responses;
+
+use Illuminate\Foundation\Testing\TestResponse;
+
+class TestResponseMacros
+{
+    public static function enable(): void
+    {
+        TestResponse::mixin(new TestResponseMixin());
+    }
+}

--- a/src/Responses/TestResponseMixin.php
+++ b/src/Responses/TestResponseMixin.php
@@ -4,20 +4,22 @@ namespace Sven\LaravelTestingUtils\Responses;
 
 use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Support\Arr;
+use Illuminate\Database\Eloquent\Model;
+use Closure;
 
 class TestResponseMixin
 {
     /**
      * Assert that a key exists in the response view's data.
      *
-     * @return \Closure
+     * @return Closure
      */
     public function assertViewHasDeep(): callable
     {
         return function ($key, $value = null) {
             $this->ensureResponseHasView();
 
-            $data = $this->original->getData();
+            $data = $this->getOriginalContent()->getData();
             $keys = explode('.', $key);
 
             foreach ($keys as $key) {

--- a/src/Responses/TestResponseMixin.php
+++ b/src/Responses/TestResponseMixin.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Sven\LaravelTestingUtils\Responses;
+
+use PHPUnit\Framework\Assert as PHPUnit;
+use Illuminate\Support\Arr;
+
+class TestResponseMixin
+{
+    /**
+     * Assert that a key exists in the response view's data.
+     *
+     * @return \Closure
+     */
+    public function assertViewHasDeep(): callable
+    {
+        return function ($key, $value = null) {
+            $this->ensureResponseHasView();
+
+            $data = $this->original->getData();
+            $keys = explode('.', $key);
+
+            foreach ($keys as $key) {
+                if (Arr::accessible($data)) {
+                    PHPUnit::assertTrue(Arr::exists($data, $key));
+                } elseif (is_object($data)) {
+                    PHPUnit::assertTrue(isset($data->{$key}));
+                } else {
+                    PHPUnit::fail('Data is not an object or array.');
+                }
+
+                $data = data_get($data, $key);
+            }
+
+            if ($value instanceof Closure) {
+                PHPUnit::assertTrue($value($data));
+            } elseif ($value instanceof Model) {
+                PHPUnit::assertTrue($value->is($data));
+            } else {
+                PHPUnit::assertEquals($value, $data);
+            }
+
+            return $this;
+        };
+    }
+}

--- a/tests/Responses/SampleModel.php
+++ b/tests/Responses/SampleModel.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Sven\LaravelTestingUtils\Tests\Responses;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SampleModel extends Model {
+    //
+}

--- a/tests/Responses/SampleModel.php
+++ b/tests/Responses/SampleModel.php
@@ -4,6 +4,7 @@ namespace Sven\LaravelTestingUtils\Tests\Responses;
 
 use Illuminate\Database\Eloquent\Model;
 
-class SampleModel extends Model {
+class SampleModel extends Model
+{
     //
 }

--- a/tests/Responses/ViewHasDeepTest.php
+++ b/tests/Responses/ViewHasDeepTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Sven\LaravelTestingUtils\Tests\Responses;
+
+use PHPUnit\Framework\AssertionFailedError;
+use Sven\LaravelTestingUtils\Responses\TestResponseMacros;
+use Sven\LaravelTestingUtils\Tests\TestCase;
+use Illuminate\Foundation\Testing\TestResponse;
+use Illuminate\Http\Response;
+
+class CollectionContainsTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        TestResponseMacros::enable();
+    }
+
+    /** @test */
+    public function response_view_has_data(): void
+    {
+        $string = 'string';
+        $integer = 123;
+        $object = (object) ['key' => 'value'];
+        $collection = collect();
+        $model = new SampleModel();
+
+        $response = $this->makeMockResponse([
+            'foo' => [
+                [
+                    'string' => $string,
+                    'integer' => $integer,
+                ],
+                [
+                    'object' => $object,
+                    'model' => $model,
+                ],
+                'collection' => $collection,
+                'any' => false,
+            ],
+        ]);
+
+        $response
+            ->assertViewHasDeep('foo.0.string', $string)
+            ->assertViewHasDeep('foo.0.integer', $integer)
+            ->assertViewHasDeep('foo.1.object', $object)
+            ->assertViewHasDeep('foo.1.model', $model)
+            ->assertViewHasDeep('foo.collection', $collection)
+            ->assertViewHasDeep('foo.any');
+    }
+
+    /** @test */
+    public function response_view_does_not_have_these_datas(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'foo' => [
+                'bar' => 'string',
+            ],
+        ]);
+
+        $response
+            ->assertViewHasDeep('foo.bar', 'not string')
+            ->assertViewHasDeep('foo.baz', 'string')
+            ->assertViewHasDeep('foo.0')
+            ->assertViewHasDeep('foo.baz');
+    }
+
+    private function makeMockResponse($content)
+    {
+        $baseResponse = tap(new Response, function (Response $response) use ($content) {
+            $response->setContent(
+                view()->file(__DIR__ . '/sample_view.php', $content)
+            );
+        });
+
+        return TestResponse::fromBaseResponse($baseResponse);
+    }
+}

--- a/tests/Responses/ViewHasDeepTest.php
+++ b/tests/Responses/ViewHasDeepTest.php
@@ -8,7 +8,7 @@ use Sven\LaravelTestingUtils\Tests\TestCase;
 use Illuminate\Foundation\Testing\TestResponse;
 use Illuminate\Http\Response;
 
-class CollectionContainsTest extends TestCase
+class ViewHasDeepTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/Responses/ViewHasDeepTest.php
+++ b/tests/Responses/ViewHasDeepTest.php
@@ -72,7 +72,7 @@ class ViewHasDeepTest extends TestCase
     {
         $baseResponse = tap(new Response, function (Response $response) use ($content) {
             $response->setContent(
-                view()->file(__DIR__ . '/sample_view.php', $content)
+                view()->file(__DIR__.'/sample_view.php', $content)
             );
         });
 


### PR DESCRIPTION
This assertion (`TestResponse::assertViewHasDeep`) is almost the same as `TestResponse::assertViewHas` except that this one accepts dot-notated keys as well!